### PR TITLE
feat: standardized ignore handling

### DIFF
--- a/src/discord/buttify.ts
+++ b/src/discord/buttify.ts
@@ -161,10 +161,8 @@ export function buttify(
     return buttifiedContent.valid ? buttifiedContent.toString() : null;
 }
 
-export async function buttifiable(message: Message<true>, frequency: number = config.default.frequency): Promise<boolean> {
-    const userModel = await IgnoreUser.findByPk(message.author.id);
+export function buttifiable(message: Message<true>, frequency: number = config.default.frequency): boolean {
     return !message.author.bot &&
         !!message.content &&
-        !userModel &&
         chance(frequency);
 }

--- a/src/discord/buttify.ts
+++ b/src/discord/buttify.ts
@@ -1,6 +1,5 @@
 import { Message } from "discord.js";
 import { syllablize } from "fast-syllablize";
-import { IgnoreUser } from "../models/index.js";
 import config from "../config.js";
 
 const ExpectedProbability = 0.95;

--- a/src/discord/ignore.ts
+++ b/src/discord/ignore.ts
@@ -3,7 +3,8 @@ import {
     Channel,
     ChannelType,
     ForumChannel,
-    GuildTextBasedChannel
+    GuildTextBasedChannel,
+    Message
 } from "discord.js";
 import {
     IgnoreChannel,
@@ -94,6 +95,14 @@ export async function unignoreUser(userId: string): Promise<boolean> {
     return !!await IgnoreUser.destroy({
         where: { id: userId }
     });
+}
+
+export async function ignoreMessage(message: Message): Promise<boolean> {
+    const [channel, user] = await Promise.all([
+        channelIgnored(message.channel),
+        IgnoreUser.findByPk(message.author.id)
+    ]);
+    return channel || !!user;
 }
 
 export type IgnorableChannel = GuildTextBasedChannel | CategoryChannel | ForumChannel;

--- a/src/discord/ignore.ts
+++ b/src/discord/ignore.ts
@@ -73,7 +73,7 @@ export async function unignoreAllChannels(guildId: string): Promise<void> {
     });
 }
 
-export async function channelIgnored(channel: Channel): Promise<boolean> {
+async function channelIgnored(channel: Channel): Promise<boolean> {
     if (!isIgnorable(channel)) {
         return false;
     }

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -19,7 +19,7 @@ import {
 } from "../constants.js";
 import { postServerCount } from "./topgg.js";
 import commands from "./commands/index.js";
-import { channelIgnored } from "./ignore.js";
+import { ignoreMessage } from "./ignore.js";
 import responses from "./responses/index.js";
 import { buttifiable, buttify } from "./buttify.js";
 import { deleteGuild, getGuild } from "./guild.js";
@@ -121,7 +121,7 @@ const client = new Client({
                             ?.has(PermissionFlagsBits.SendMessages)
                     )
                 ) &&
-                !await channelIgnored(message.channel)
+                !await ignoreMessage(message)
             ) {
                 if (
                     message.mentions.users.has(message.client.user.id) ||

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -139,7 +139,7 @@ const client = new Client({
                     return;
                 }
                 const guildModel = await getGuild(message.guildId);
-                if (await buttifiable(message, guildModel?.frequency)) {
+                if (buttifiable(message, guildModel?.frequency)) {
                     const buttified = buttify(
                         message.content,
                         guildModel?.word,


### PR DESCRIPTION
Previously, ignored users could still trigger emoji responses due to user ignores being handled at the 'buttifiable' check stage. Ignored channels would entirely be ignored for both buttification and responses.
All ignores will now be handled for all messages in general. Which is to say, the behavior for channel ignores is not changing. User ignores will now prevent emoji responses.